### PR TITLE
Mark micro 2.0.8+ as supported versions

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -8,7 +8,7 @@
       "Version": "0.4.1",
       "Url": "https://github.com/AndCake/micro-plugin-lsp/archive/v0.4.1.zip",
       "Require": {
-        "micro": ">=2.0.10"
+        "micro": ">=2.0.8"
       }
     }
   ]


### PR DESCRIPTION
This allows LSP plugin to work with micro version that's installed with Debian 11-Bullseye package management (apt-get install micro).

I have tested that LSP plugin works with that version, and my test is detailed on https://terokarvinen.com/2022/micro-editor-lsp-support-python-and-go-jump-to-definition-show-function-signature/

The version requirement could be lower than that, maybe 2.0.0, but I have only tested with 2.0.8.