### PR TITLE
6: :star2: adds references lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Currently implemented methods:
 - textDocument/definition
 - textDocument/completion
 - textDocument/formatting
+- textDocument/references
 
 If possible, this plugin will register the following shortcuts:
 
 - Alt-k for hover
 - Alt-d for definition lookup
 - Alt-f for formatting
+- Alt-r for looking up references
 - Ctrl-space for completion
 
 ## Installation

--- a/help/lsp.md
+++ b/help/lsp.md
@@ -10,6 +10,8 @@ This help page can be viewed in Micro editor with Ctrl-E 'help lsp'
 - Show function signature on status bar (alt-K) (textDocument/hover)
 - Open function definition in a new tab (alt-D) (textDocument/definition)
 - Format document (alt-F) (textDocument/formatting)
+- Show references to the current symbol in a buffer (alt-R) (textDocument/references), 
+  pressing return on the reference line, the reference's location is opened in a new tab
 
 There is initial support for completion (ctrl-space) (textDocument/completion).
 


### PR DESCRIPTION
This PR will allow looking up references of a given symbol. Just select the symbol with the cursor and press Alt-r. This will create a new horizontal split in which all references to the symbol are listed. When one such reference is selected (by pressing return), the corresponding file opens at the given location in a new tab.

This behavior should be familiar to people who have used the Find All feature in Sublime Text.