### PR TITLE
Bugfix/11 looking for cargo

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -215,7 +215,6 @@ end
 
 function onStdout(filetype)
 	return function (text)
-		micro.Log("Received", filetype, text)
 		if text:starts("Content-Length:") then
 			message = text
 		else
@@ -255,7 +254,11 @@ function onStdout(filetype)
 			currentAction.response(bp, data)
 			currentAction = {}
 		elseif data.method == "window/showMessage" or data.method == "window\\/showMessage" then
-			micro.InfoBar():Message(data.params.message)
+			if filetype == micro.CurPane().Buf:FileType() then
+				micro.InfoBar():Message(data.params.message)
+			else
+				micro.Log(filetype .. " message " .. data.params.message)
+			end
 		elseif data.method == "window/logMessage" or data.method == "window\\/logMessage" then
 			micro.Log(data.params.message)
 		elseif currentAction.method == "initialize" then
@@ -274,6 +277,7 @@ end
 
 function onStderr(text)
 	micro.Log("ONSTDERR", text)
+	micro.InfoBar():Message(text)
 end
 
 function onExit(str)

--- a/main.lua
+++ b/main.lua
@@ -274,12 +274,10 @@ end
 
 function onStderr(text)
 	micro.Log("ONSTDERR", text)
-	micro.InfoBar():Error(text)
 end
 
 function onExit(str)
 	micro.Log("ONEXIT", text)
-	micro.InfoBar():Error(str)
 end
 
 -- the actual hover action request and response


### PR DESCRIPTION
Only shows the log messages in the info bar if they are relevant to the current document. Otherwise they are now just logged into the regular log file.