### PR TITLE
20: :bug: fixes jittering on publishDiagnostics

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -257,6 +257,7 @@ function onStdout(filetype)
 			-- react to server-published event
 			local bp = micro.CurPane().Buf
 			bp:ClearMessages("lsp")
+			bp:AddMessage(buffer.NewMessage("lsp", "", buffer.Loc(0, 10000000), buffer.Loc(0, 10000000), buffer.MTInfo))
 			local uri = getUriFromBuf(bp)
 			if data.params.uri == uri then
 				for _, diagnostic in ipairs(data.params.diagnostics) do


### PR DESCRIPTION
create an empty info message outside the visible range to keep the message gutter opened, thus avoiding any jitter during typing.