### PR TITLE
Fixed bug when the file from goToDefinition is not in subdirectory

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -443,7 +443,7 @@ function definitionActionResponse(bp, data)
 	local buf = bp.Buf
 	if file ~= doc then
 		-- it's from a different file, so open it as a new tab
-		buf, _ = buffer.NewBufferFromFile("." .. uri:sub(#rootUri + 1, #uri))
+		buf, _ = buffer.NewBufferFromFile(doc)
 		bp:AddTab()
 		micro.CurPane():OpenBuffer(buf)
 	end


### PR DESCRIPTION
the `definition` feature didn't work when the file returned by the server wasn't in the working directory, as is often the case with dependencies. This commit fixes this bug.