### PR TITLE
Wrong separator in the config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Example:
 	"lsp.formatOnSave": true,
 	"lsp.ignoreMessages": "LS message1 to ignore|LS message 2 to ignore|...",
 	"lsp.tabcompletion": true,
-	"lsp.ignoreTriggerCharacters", "completion,signature",
+	"lsp.ignoreTriggerCharacters": "completion,signature",
 	"lsp.autocompleteDetails": false
 }
 ```


### PR DESCRIPTION
The example configuration will not work without this fix.