### PR TITLE
default to rust-analyzer instead of rls, implement textDocument/didSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example:
 
 ```
 {
-	"lsp.server": "python=pyls,go=gopls,typescript=deno lsp,rust=rls",
+	"lsp.server": "python=pyls,go=gopls,typescript=deno lsp,rust=rust-analyzer",
 	"lsp.formatOnSave": true,
 	"lsp.ignoreMessages": "LS message1 to ignore|LS message 2 to ignore|...",
 	"lsp.tabcompletion": true,
@@ -65,14 +65,14 @@ information. If set, it will override the `lsp.server` from the `settings.json`.
 You can add a line such as the following to your shell profile (e.g. .bashrc):
 
 ```
-export MICRO_LSP='python=pyls,go=gopls,typescript=deno lsp={"importMap":"import_map.json"},rust=rls'
+export MICRO_LSP='python=pyls,go=gopls,typescript=deno lsp={"importMap":"import_map.json"},rust=rust-analyzer'
 ```
 
 If neither the MICRO_LSP nor the lsp.server is set, then the plugin falls back
 to the following settings:
 
 ```
-python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rls,lua=lua-lsp,c++=clangd
+python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rust-analyzer,lua=lua-lsp,c++=clangd
 ```
 
 The option `lsp.autocompleteDetails` allows for showing all auto-completions in

--- a/help/lsp.md
+++ b/help/lsp.md
@@ -57,12 +57,12 @@ wish to use the Palantir version (last updated in 2020) instead, set
 
 If your lsp.server settings are autoremoved, you can
 
-    $ export MICRO_LSP='python=pylsp,go=gopls,typescript=deno lsp={"importMap":"import_map.json"},rust=rls'
+    $ export MICRO_LSP='python=pylsp,go=gopls,typescript=deno lsp={"importMap":"import_map.json"},rust=rust-analyzer'
 
 The lsp.server default settings (if no others are defined) are:
 
 ```
-python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rls,lua=lua-lsp,c++=clangd
+python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rust-analyzer,lua=lua-lsp,c++=clangd
 ```
 
 ## Install Language Server
@@ -306,7 +306,9 @@ the useful ones.
 
 [mypy - Optional Static Typing for Python](http://mypy-lang.org/)
 
-[rls - Rust Language Server](https://github.com/rust-lang/rls)
+[rust-analyzer](https://github.com/rust-lang/rust-analyzer)
+
+[rls - Rust Language Server](https://github.com/rust-lang/rls) (deprecated)
 
 [deno](https://deno.land/)
 

--- a/main.lua
+++ b/main.lua
@@ -72,7 +72,7 @@ function startServer(filetype, callback)
 	rootUri = fmt.Sprintf("file://%s", wd)
 	local envSettings, _ = go_os.Getenv("MICRO_LSP")
 	local settings = config.GetGlobalOption("lsp.server")
-	local fallback = "python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rls,lua=lua-lsp,c++=clangd"
+	local fallback = "python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rust-analyzer,lua=lua-lsp,c++=clangd"
 	if envSettings ~= nil and #envSettings > 0 then
 		settings = envSettings
 	end
@@ -242,6 +242,18 @@ function preSave(bp)
 			bp:Save()
 		end)
 	end
+end
+
+function onSave(bp)
+	local filetype = bp.Buf:FileType()
+	if cmd[filetype] == nil then
+		return
+	end
+
+	local send = withSend(filetype)
+	local uri = getUriFromBuf(bp.Buf)
+
+	send("textDocument/didSave", fmt.Sprintf('{"textDocument": {"uri": "%s"}}', uri), true)
 end
 
 function handleInitialized(buf, filetype)

--- a/main.lua
+++ b/main.lua
@@ -107,7 +107,7 @@ function startServer(filetype, callback)
 end
 
 function init()
-	config.RegisterCommonOption("lsp", "server", "python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rls,lua=lua-lsp,c++=clangd")
+	config.RegisterCommonOption("lsp", "server", "python=pylsp,go=gopls,typescript=deno lsp,javascript=deno lsp,markdown=deno lsp,json=deno lsp,jsonc=deno lsp,rust=rust-analyzer,lua=lua-lsp,c++=clangd")
 	config.RegisterCommonOption("lsp", "formatOnSave", true)
 	config.RegisterCommonOption("lsp", "autocompleteDetails", false)
 	config.RegisterCommonOption("lsp", "ignoreMessages", "")


### PR DESCRIPTION
> RLS has been deprecated and is no longer supported. It has been replaced with [rust-analyzer](https://rust-analyzer.github.io/). Users are encouraged to uninstall RLS and follow the instructions in the rust-analyzer manual to install it for your editor.

(Source: https://github.com/rust-lang/rls)

I also noticed [Rust language servers are only able to do type checking when a file is saved](https://users.rust-lang.org/t/rust-analyzer-doesnt-check-the-buffer-on-typing-but-only-on-save-how-to-change-that/79221/7) so I implemented the [`textDocument/didSave`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didSave) notification. This nets us a few more diagnostics (although micro's [built-in linter plugin also runs cargo clippy](https://github.com/zyedidia/micro/blob/1231d242794d6aed0e65f41316db284ff9dcbec7/runtime/plugins/linter/linter.lua#L74) on save so there's some overlap if you have that enabled). Anyway I'm sure various other language servers also benefit from this notification.