### PR TITLE
format: Use current settings for formatting

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -768,9 +768,10 @@ function formatAction(bp, callback)
 	if cmd[filetype] == nil then return; end
 	local send = withSend(filetype)
 	local file = bp.Buf.AbsPath
+	local cfg = bp.Buf.Settings
 
 	currentAction[filetype] = { method = "textDocument/formatting", response = formatActionResponse(callback) }
-	send(currentAction[filetype].method, fmt.Sprintf('{"textDocument": {"uri": "file://%s"}, "options": {"tabSize": 4, "insertSpaces": true}}', file))
+	send(currentAction[filetype].method, fmt.Sprintf('{"textDocument": {"uri": "file://%s"}, "options": {"tabSize": %.0f, "insertSpaces": %t, "trimTrailingWhitespace": %t, "insertFinalNewline": %t}}', file, cfg["tabsize"], cfg["tabstospaces"], cfg["rmtrailingws"], cfg["eofnewline"]))
 end
 
 function formatActionResponse(callback)


### PR DESCRIPTION
Instead of hard-coding default values,
use the current settings to determine the options
to pass the language server
for the textDocument/formatting call.

Also pass values for `trimTrailingWhitespace` and `insertFinalNewline`
because micro has settings for those too.
